### PR TITLE
Set more appropriate keywords for package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,9 @@
   "version": "1.2.1",
   "description": "Syntax highlighting, autocomplete and lint for the Elm language extended with embedded HTML (elmx)",
   "keywords": [
-    "ide-haskell",
-    "ide",
-    "haskell",
-    "ghc-mod",
-    "backend"
+    "language",
+    "elm",
+    "elmx"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm building a Atom Packages directory on http://atom-packages.directory/, currently this package is listed under Haskell, with these keywords it will be put into the right category for Elm. http://atom-packages.directory/category/languages-elm/

It would be awesome to use these so it can be better found.
