### PR TITLE
Only delete files that exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ const mapError = filePath => error => R.merge(error, {
 });
 
 const removeFile = R.curry((filePath, arg) => {
-  fs.unlinkSync(filePath);
+  if (fs.exists(filePath)) {
+    fs.unlinkSync(filePath);
+  }
   return arg;
 });
 


### PR DESCRIPTION
Fixes issues when retain is false, because it tries to delete (at least) once too many times.
It would be better to figure out why it deletes once too many, but alas time is of the essence.